### PR TITLE
More mcmc

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [ "Programming Language :: Python" ]
 dependencies = ["numpy", "astropy", "jax", "jaxlib", "dill", "jitkasi @ git+https://github.com/MUSTANG-SZ/jitkasi.git", "cython", "mpi4py", "mpi4jax","typing_extensions"]
 
 [project.optional-dependencies]
-fitter = ["pyyaml", "minkasi", "emcee", "corner"]
+fitter = ["pyyaml", "minkasi", "emcee", "corner", "tqdm"]
 profile = ["tensorflow", "gitpython"]
 docs = [
     "mkdocs",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,10 +16,10 @@ requires-python = ">=3.8"
 keywords = ["galaxy clusters", "tSZ", "Sunyaev–Zeldovich", "MUSTANG2", "jax", "minkasi"]
 license = {text = "GPLv3"}
 classifiers = [ "Programming Language :: Python" ]
-dependencies = ["numpy", "astropy", "jax", "jaxlib", "dill", "jitkasi @ git+https://github.com/MUSTANG-SZ/jitkasi.git", "cython", "mpi4py", "mpi4jax"]
+dependencies = ["numpy", "astropy", "jax", "jaxlib", "dill", "jitkasi @ git+https://github.com/MUSTANG-SZ/jitkasi.git", "cython", "mpi4py", "mpi4jax","typing_extensions"]
 
 [project.optional-dependencies]
-fitter = ["pyyaml", "minkasi"]
+fitter = ["pyyaml", "minkasi", "emcee", "corner"]
 profile = ["tensorflow", "gitpython"]
 docs = [
     "mkdocs",

--- a/unit_tests/mcmc_check.yaml
+++ b/unit_tests/mcmc_check.yaml
@@ -10,8 +10,9 @@ sim: True # If True use TODs to make noise and add a simulated cluster
 
 mcmc:
   run: True
-  num_steps: 1000
+  num_steps: 300
   num_walkers: 10
+  sample_which: -1
 
 model:
   # Unit conversion to apply at the end
@@ -19,7 +20,41 @@ model:
   unit_conversion: "float(wu.get_da(constants['z'])*wu.y2K_RJ(constants['freq'], constants['Te'])*wu.XMpc/wu.me)"
   # Structure to include in the model
   structures:
-    # Name of the first structure
+    # isobeta:
+    #   structure: "isobeta"
+    #   parameters:
+    #     dx_g:
+    #       value: 0.0
+    #       to_fit: True # [True, True, False, True]
+    #       priors: [-9.0, 9.0]
+    #     dy_g:
+    #       value: 0.0
+    #       to_fit: True #[True, True, False, True]
+    #       priors: [-9.0, 9.0]
+    #     dz_g:
+    #       value: 0.0
+    #       to_fit: True #[True, True, False, True]
+    #       priors: [-9.0, 9.0]
+    #     r1_g:
+    #       value: 1.0
+    #       priors: [.1, 9.0]
+    #     r2_g:
+    #       value: 1.0
+    #       priors: [.1, 9.0]
+    #     r3_g:
+    #       value: 1.0
+    #       priors: [.1, 9.0]
+    #     theta:
+    #       value: .0
+    #       priors: [0, 6.29]
+    #     beta_1:
+    #       value: .98
+    #       to_fit: True
+    #       priors: [.1, 2]
+    #     amp_1:
+    #       value: .002
+    #       to_fit: True
+    #       priors: [0, .005]
     ps_gauss:
       structure: "gaussian"
       parameters:
@@ -33,8 +68,9 @@ model:
           priors: [-9.0, 9.0]
         sigma:
           value: 4
+          to_fit: [False, True, False, True]
           priors: [1, 10]
         amp_g:
           value: 0.002
-          to_fit: [True, False, True, True]
+          to_fit: [True, False, True, False]
           priors: [0, .005]

--- a/unit_tests/mcmc_check.yaml
+++ b/unit_tests/mcmc_check.yaml
@@ -2,6 +2,8 @@
 # If an absolute path is given then it is used
 # Otherwise it is assumed to me reative to the directory of this file
 base: "base_unit.yaml"
+n_rounds: 1
+wnoise: True
 
 # Cluster name
 # Used both for the output path as well as to load presets
@@ -10,8 +12,7 @@ sim: True # If True use TODs to make noise and add a simulated cluster
 
 mcmc:
   run: True
-  num_steps: 300
-  num_walkers: 10
+  num_steps: 1000
   sample_which: -1
 
 model:
@@ -60,17 +61,17 @@ model:
       parameters:
         dx_g:
           value: 0.0
-          to_fit: [True, True, False, True]
+          to_fit: True #[True, True, False, True]
           priors: [-9.0, 9.0]
         dy_g:
           value: 0.0
-          to_fit: [True, True, False, True]
+          to_fit: True #[True, True, False, True]
           priors: [-9.0, 9.0]
         sigma:
           value: 4
-          to_fit: [False, True, False, True]
+          to_fit: True #[False, True, False, True]
           priors: [1, 10]
         amp_g:
           value: 0.002
-          to_fit: [True, False, True, False]
+          to_fit: True #[True, False, True, False]
           priors: [0, .005]

--- a/unit_tests/mcmc_check.yaml
+++ b/unit_tests/mcmc_check.yaml
@@ -1,0 +1,40 @@
+# Base config to merge into
+# If an absolute path is given then it is used
+# Otherwise it is assumed to me reative to the directory of this file
+base: "base_unit.yaml"
+
+# Cluster name
+# Used both for the output path as well as to load presets
+name: "SIM_MCMC"
+sim: True # If True use TODs to make noise and add a simulated cluster
+
+mcmc:
+  run: True
+  num_steps: 1000
+  num_walkers: 10
+
+model:
+  # Unit conversion to apply at the end
+  # Will be evaled
+  unit_conversion: "float(wu.get_da(constants['z'])*wu.y2K_RJ(constants['freq'], constants['Te'])*wu.XMpc/wu.me)"
+  # Structure to include in the model
+  structures:
+    # Name of the first structure
+    ps_gauss:
+      structure: "gaussian"
+      parameters:
+        dx_g:
+          value: 0.0
+          to_fit: [True, True, False, True]
+          priors: [-9.0, 9.0]
+        dy_g:
+          value: 0.0
+          to_fit: [True, True, False, True]
+          priors: [-9.0, 9.0]
+        sigma:
+          value: 4
+          priors: [1, 10]
+        amp_g:
+          value: 0.002
+          to_fit: [True, False, True, True]
+          priors: [0, .005]

--- a/unit_tests/sim_unit.yaml
+++ b/unit_tests/sim_unit.yaml
@@ -34,23 +34,32 @@ model:
           priors: [-9.0, 9.0]
         dz_1:
           value: 0.0 
+          priors: [-9.0, 9.0]
         theta:
           value: 0.0
+          priors: [0, 6.29]
         P0:
           value: 8.403
+          priors: [6, 10]
         c500:
           value: 1.177 
+          priors: [1, 3]
         m500:
           value: "1.5e15"
           to_fit: [True, False, True, True] 
+          priors: ["1e14", "1e16"]
         gamma:
           value: .3081 
+          priors: [.05, 1]
         alpha:
           value: 1.551 
+          priors: [.05, 3]
         beta:
           value: 5.4905 
+          priors: [.05, 10]
         z:
           value: 0.97 
+          priors: [.9, 1]
     ps_gauss:
       structure: "gaussian"
       parameters:
@@ -64,26 +73,35 @@ model:
           priors: [-9.0, 9.0]
         sigma:
           value: 4
+          priors: [1, 10]
         amp_g:
           value: 0.002
           to_fit: [True, False, True, True]
+          priors: [0, .005]
     bubble_ne:
       structure: "uniform"
       parameters:
         b_ne_ra:
           value: "-15"
+          priors: [-20, -10]
         b_ne_dec:
           value: "15"
+          priors: [10, 20]
         b_ne_z:
           value: "0"
+          priors: [-10, 10]
         b_ne_r1:
           value: "30"
+          priors: [20, 40]
         b_ne_r2:
           value: "30"
+          priors: [20, 40]
         b_ne_r3:
           value: "30"
+          priors: [20, 40]
         b_ne_theta:
           value: 0
+          priors: [0, 6.29]
         b_ne_sup:
           value: -0.75
           to_fit: [False, True, True, True]
@@ -93,18 +111,25 @@ model:
       parameters:
         b_sw_ra:
           value: "15"
+          priors: [10, 20]
         b_sw_dec:
           value: "-15"
+          priors: [-20, -10]
         b_sw_z:
           value: "0"
+          priors: [-10, 10]
         b_sw_r1:
           value: "30"
+          priors: [20, 40]
         b_sw_r2:
           value: "30"
+          priors: [20, 40]
         b_sw_r3:
           value: "30"
+          priors: [20, 40]
         b_sw_theta:
           value: 0
+          priors: [0, 6.29]
         b_sw_sup:
           value: -0.75
           to_fit: [False, True, True, True]

--- a/witch/containers.py
+++ b/witch/containers.py
@@ -413,9 +413,11 @@ class Model:
             The model as a TOD.
             Same shape as dx.
         """
-        return wu.bilinear_interp(
+        tod = wu.bilinear_interp(
             dx, dy, self.xyz[0].ravel(), self.xyz[1].ravel(), self.model
         )
+        tod = tod - jnp.mean(tod, axis=-1)[..., None]
+        return tod
 
     def to_tod_grad(self, dx: ArrayLike, dy: ArrayLike) -> tuple[jax.Array, jax.Array]:
         """
@@ -441,6 +443,7 @@ class Model:
         tod = wu.bilinear_interp(
             dx, dy, self.xyz[0].ravel(), self.xyz[1].ravel(), model
         )
+        tod = tod - jnp.mean(tod, axis=-1)[..., None]
         grad_tod = jnp.array(
             [
                 (

--- a/witch/containers.py
+++ b/witch/containers.py
@@ -560,7 +560,6 @@ class Model:
         ----------
         cfg : dict
             The config loaded into a dict.
-
         beam : Optional[Array], default: None
 
         Returns

--- a/witch/external/minkasi/funcs.py
+++ b/witch/external/minkasi/funcs.py
@@ -177,9 +177,10 @@ def postproc(dset_name: str, cfg: dict, todvec: TODVec, model: Model, info: dict
                 tod.noise = from_minkasi_noise(tod_minkasi)
         else:
             for tod, tod_minkasi in zip(todvec, todvec_minkasi.tods):
-                mat = 0 * tod_minkasi.info["dat_calib"]
+                mat = 0 * tod_minkasi.info["dat_calib"].copy()
                 for m in mapset.maps:
                     m.map2tod(tod_minkasi, mat)
+                mat -= np.mean(mat, axis=-1)[..., None]  # Avoid overflow
                 tod.recompute_noise(
                     data=tod.data - jnp.array(mat),
                     *info["noise_args"],

--- a/witch/fitter.py
+++ b/witch/fitter.py
@@ -17,9 +17,9 @@ import matplotlib.pyplot as plt
 import mpi4jax
 import numpy as np
 import yaml
-from mpi4py import MPI
 from astropy.convolution import Gaussian2DKernel, convolve
 from minkasi.tools import presets_by_source as pbs
+from mpi4py import MPI
 from typing_extensions import Any, Unpack
 
 from . import utils as wu
@@ -160,7 +160,7 @@ def _save_model(cfg, model, outdir, desc_str):
             final["model"]["structures"][struct_name]["parameters"][par_name][
                 "value"
             ] = float(par.val)
-    with open(os.path.join(outdir, f"mcmc_{desc_str}.yaml"), "w") as file:
+    with open(os.path.join(outdir, f"results_{desc_str}.yaml"), "w") as file:
         yaml.dump(final, file)
 
 
@@ -227,12 +227,12 @@ def _run_mcmc(cfg, model, todvec, outdir, noise_class, noise_args, noise_kwargs)
     _save_model(cfg, model, outdir, "mcmc")
     if comm.Get_rank() == 0:
         samples = np.array(samples)
-        samps_path = os.path.join(outdir, f"samples_mcmc.dill")
+        samps_path = os.path.join(outdir, f"samples_mcmc.npz")
         print_once("Saving samples to", samps_path)
         np.savez_compressed(samps_path, samples=samples)
         try:
             corner.corner(samples, labels=model.par_names, truths=init_pars)
-            plt.savefig("corner.png")
+            plt.savefig(os.path.join(outdir, "corner.png"))
         except Exception as e:
             print_once(f"Failed to make corner plot with error: {str(e)}")
     else:

--- a/witch/fitter.py
+++ b/witch/fitter.py
@@ -18,6 +18,8 @@ import numpy as np
 import yaml
 from jitkasi.tod import TOD
 from mpi4py import MPI
+from astropy.convolution import Gaussian2DKernel, convolve
+from minkasi.tools import presets_by_source as pbs
 from typing_extensions import Any, Unpack
 
 from . import utils as wu
@@ -25,8 +27,6 @@ from .containers import Model
 from .fitting import fit_tods, objective
 
 comm = MPI.COMM_WORLD.Clone()
-
-import pdb
 
 
 def print_once(*args: Unpack[tuple[Any, ...]]):

--- a/witch/fitter.py
+++ b/witch/fitter.py
@@ -220,7 +220,9 @@ def _run_mcmc(cfg, model, todvec, outdir, noise_class, noise_args, noise_kwargs)
         model,
         todvec,
         num_steps=int(cfg["mcmc"].get("num_steps", 5000)),
-        num_walkers=int(cfg["mcmc"].get("num_walkers", 10)),
+        num_leaps=int(cfg["mcmc"].get("num_leaps", 10)),
+        step_size=float(cfg["mcmc"].get("step_size", 0.02)),
+        sample_which=int(cfg["mcmc"].get("sample_which", -1)),
     )
     _ = mpi4jax.barrier(comm=comm)
     t2 = time.time()

--- a/witch/fitter.py
+++ b/witch/fitter.py
@@ -10,13 +10,13 @@ import time
 from copy import deepcopy
 from importlib import import_module
 
+import corner
 import jax
 import jax.numpy as jnp
-import minkasi
+import matplotlib.pyplot as plt
 import mpi4jax
 import numpy as np
 import yaml
-from jitkasi.tod import TOD
 from mpi4py import MPI
 from astropy.convolution import Gaussian2DKernel, convolve
 from minkasi.tools import presets_by_source as pbs
@@ -24,7 +24,7 @@ from typing_extensions import Any, Unpack
 
 from . import utils as wu
 from .containers import Model
-from .fitting import fit_tods, objective
+from .fitting import fit_tods, objective, run_mcmc
 
 comm = MPI.COMM_WORLD.Clone()
 
@@ -134,12 +134,113 @@ def get_outdir(cfg, model):
         outdir += "-sim"
 
     print_once("Outputs can be found in", outdir)
-    if minkasi.myrank == 0:
+    if comm.Get_rank() == 0:
         os.makedirs(outdir, exist_ok=True)
         with open(os.path.join(outdir, "config.yaml"), "w") as file:
             yaml.dump(cfg, file)
 
     return outdir
+
+
+def _save_model(cfg, model, outdir, desc_str):
+    if comm.Get_rank() != 0:
+        return
+    res_path = os.path.join(outdir, f"results_{desc_str}.dill")
+    print_once("Saving results to", res_path)
+    model.save(res_path)
+
+    final = {"model": cfg["model"]}
+    for i, (struct_name, structure) in zip(
+        model.original_order, cfg["model"]["structures"].items()
+    ):
+        model_struct = model.structures[i]
+        for par, par_name in zip(
+            model_struct.parameters, structure["parameters"].keys()
+        ):
+            final["model"]["structures"][struct_name]["parameters"][par_name][
+                "value"
+            ] = float(par.val)
+    with open(os.path.join(outdir, f"mcmc_{desc_str}.yaml"), "w") as file:
+        yaml.dump(final, file)
+
+
+def _reestimate_noise(model, todvec, noise_class, noise_args, noise_kwargs):
+    for tod in todvec:
+        pred = model.to_tod(
+            tod.x * wu.rad_to_arcsec, tod.y * wu.rad_to_arcsec
+        ).block_until_ready()
+        tod.compute_noise(noise_class, tod.data - pred, *noise_args, **noise_kwargs)
+    return todvec
+
+
+def _run_fit(cfg, model, todvec, outdir, r, noise_class, noise_args, noise_kwargs):
+    model.cur_round = r
+    to_fit = np.array(model.to_fit)
+    print_once(f"Starting round {r+1} of fitting with {np.sum(to_fit)} pars free")
+    t1 = time.time()
+    model, i, delta_chisq = fit_tods(
+        model,
+        todvec,
+        eval(str(cfg["fitting"].get("maxiter", "10"))),
+        eval(str(cfg["fitting"].get("chitol", "1e-5"))),
+    )
+    _ = mpi4jax.barrier(comm=comm)
+    t2 = time.time()
+    print_once(
+        f"Took {t2 - t1} s to fit with {i} iterations and final delta chisq of {delta_chisq}"
+    )
+
+    print_once(model)
+    _save_model(cfg, model, outdir, f"fit{r}")
+
+    todvec = _reestimate_noise(model, todvec, noise_class, noise_args, noise_kwargs)
+    return model, todvec
+
+
+def _run_mcmc(cfg, model, todvec, outdir, noise_class, noise_args, noise_kwargs):
+    print_once("Running MCMC")
+    no_priors = ~np.isfinite(
+        np.array(jnp.abs(model.priors[0]) + jnp.abs(model.priors[1]))
+    )
+    if np.sum(no_priors) != 0:
+        print_once(
+            f"{np.sum(no_priors)} parameters without priors found!:\n {[name for name, nprior in zip(model.par_names, no_priors) if nprior]}\nCan't run MCMC! Moving on..."
+        )
+        return model
+
+    init_pars = np.array(model.pars.copy())
+    t1 = time.time()
+    model, samples = run_mcmc(
+        model,
+        todvec,
+        num_steps=int(cfg["mcmc"].get("num_steps", 5000)),
+        num_walkers=int(cfg["mcmc"].get("num_walkers", 10)),
+    )
+    _ = mpi4jax.barrier(comm=comm)
+    t2 = time.time()
+    print_once(f"Took {t2 - t1} s to run mcmc")
+
+    message = str(model).split("\n")
+    message[1] = "MCMC estimated pars:"
+    print_once("\n".join(message))
+
+    _save_model(cfg, model, outdir, "mcmc")
+    if comm.Get_rank() == 0:
+        samples = np.array(samples)
+        samps_path = os.path.join(outdir, f"samples_mcmc.dill")
+        print_once("Saving samples to", samps_path)
+        np.savez_compressed(samps_path, samples=samples)
+        try:
+            corner.corner(samples, labels=model.par_names, truths=init_pars)
+            plt.savefig("corner.png")
+        except Exception as e:
+            print_once(f"Failed to make corner plot with error: {str(e)}")
+    else:
+        # samples are incomplete on non root procs
+        del samples
+
+    todvec = _reestimate_noise(model, todvec, noise_class, noise_args, noise_kwargs)
+    return model, todvec
 
 
 def deep_merge(a: dict, b: dict) -> dict:
@@ -175,10 +276,6 @@ def load_config(start_cfg, cfg_path):
 
 
 def main():
-    # Check if we have MPI
-    if minkasi.comm is None:
-        raise RuntimeError("Running without MPI is not currently supported!")
-
     parser = _make_parser()
     args = parser.parse_args()
 
@@ -264,7 +361,6 @@ def main():
     if cfg["fit"]:
         if model is None:
             raise ValueError("Can't fit without a model defined!")
-
         if cfg["sim"]:
             # Remove structs we deliberately want to leave out of model
             for struct_name in cfg["model"]["structures"]:
@@ -285,53 +381,16 @@ def main():
         message[1] = "Starting pars:"
         print_once("\n".join(message))
         for r in range(model.n_rounds):
-            model.cur_round = r
-            to_fit = np.array(model.to_fit)
-            print_once(
-                f"Starting round {r+1} of fitting with {np.sum(to_fit)} pars free"
-            )
-            t1 = time.time()
-            model, i, delta_chisq = fit_tods(
-                model,
-                todvec,
-                eval(str(cfg["fitting"].get("maxiter", "10"))),
-                eval(str(cfg["fitting"].get("chitol", "1e-5"))),
+            model, todvec = _run_fit(
+                cfg, model, todvec, outdir, r, noise_class, noise_args, noise_kwargs
             )
             _ = mpi4jax.barrier(comm=comm)
-            t2 = time.time()
-            print_once(
-                f"Took {t2 - t1} s to fit with {i} iterations and final delta chisq of {delta_chisq}"
+
+        if "mcmc" in cfg and cfg["mcmc"].get("run", True):
+            model, todvec = _run_mcmc(
+                cfg, model, todvec, outdir, noise_class, noise_args, noise_kwargs
             )
-
-            print_once(model)
-
-            if minkasi.myrank == 0:
-                res_path = os.path.join(outdir, f"results_{r}.dill")
-                print_once("Saving results to", res_path)
-                # TODO: switch to h5?
-                model.save(res_path)
-
-            # Reestimate noise
-            for tod in todvec:
-                pred = model.to_tod(tod.x * wu.rad_to_arcsec, tod.y * wu.rad_to_arcsec)
-                tod.compute_noise(
-                    noise_class, tod.data - pred, *noise_args, **noise_kwargs
-                )
             _ = mpi4jax.barrier(comm=comm)
-        # Save final pars
-        final = {"model": cfg["model"]}
-        for i, (struct_name, structure) in zip(
-            model.original_order, cfg["model"]["structures"].items()
-        ):
-            model_struct = model.structures[i]
-            for par, par_name in zip(
-                model_struct.parameters, structure["parameters"].keys()
-            ):
-                final["model"]["structures"][struct_name]["parameters"][par_name][
-                    "value"
-                ] = float(par.val)
-        with open(os.path.join(outdir, "fit_params.yaml"), "w") as file:
-            yaml.dump(final, file)
 
     postfit(dset_name, cfg, todvec, model, info)
 

--- a/witch/fitting.py
+++ b/witch/fitting.py
@@ -1,12 +1,13 @@
+import time
 from functools import partial
+from typing import Callable
 
-import emcee
 import jax
 import jax.numpy as jnp
 import mpi4jax
-import numpy as np
 from jitkasi.tod import TODVec
 from mpi4py import MPI
+from tqdm import tqdm
 
 from . import utils as wu
 from .containers import Model
@@ -155,6 +156,7 @@ def get_chisq(model: Model, todvec: TODVec) -> jax.Array:
     Returns
     -------
     chisq : jax.Array
+        The chi-squared of the model.
     """
     token = mpi4jax.barrier(comm=todvec.comm)
     chisq = jnp.array(0)
@@ -172,6 +174,106 @@ def get_chisq(model: Model, todvec: TODVec) -> jax.Array:
     _ = mpi4jax.barrier(comm=todvec.comm, token=token)
 
     return chisq
+
+
+@jax.jit
+def get_grad(model: Model, todvec: TODVec) -> jax.Array:
+    """
+    Get the gradient of chi-squared of a model given a set of TODs.
+    This is an MPI aware function.
+
+    Parameters
+    ----------
+    model : Model
+        The model object we are using to fit.
+    todvec : TODVec
+        The TODs to fit against.
+        This is what we use to compute our fit residuals.
+
+    Returns
+    -------
+    grad : jax.Array
+        The gradient of the parameters at there current values.
+        This is a `(npar,)` array.
+    """
+    token = mpi4jax.barrier(comm=todvec.comm)
+    npar = len(model.pars)
+    grad = jnp.zeros(npar)
+    for tod in todvec:
+        x = tod.x * wu.rad_to_arcsec
+        y = tod.y * wu.rad_to_arcsec
+
+        pred_tod, grad_tod = model.to_tod_grad(x, y)
+        ndet, nsamp = tod.shape
+
+        resid = tod.data - pred_tod
+
+        grad_filt = jnp.zeros_like(grad_tod)
+        for i in range(npar):
+            grad_filt = grad_filt.at[i].set(tod.noise.apply_noise(grad_tod.at[i].get()))
+        grad_filt = jnp.reshape(grad_filt, (npar, ndet * nsamp))
+        grad_tod = jnp.reshape(grad_tod, (npar, ndet * nsamp))
+        resid = jnp.reshape(resid, (ndet * nsamp,))
+
+        grad = grad.at[:].add(jnp.dot(grad_filt, jnp.transpose(resid)))
+
+    grad, token = mpi4jax.allreduce(grad, MPI.SUM, comm=todvec.comm, token=token)
+    _ = mpi4jax.barrier(comm=todvec.comm, token=token)
+
+    return grad
+
+
+@jax.jit
+def get_chisq_grad(model: Model, todvec: TODVec) -> jax.Array:
+    """
+    Get the chi-squared and gradient of a model given a set of TODs.
+    This is an MPI aware function.
+
+    Parameters
+    ----------
+    model : Model
+        The model object we are using to fit.
+    todvec : TODVec
+        The TODs to fit against.
+        This is what we use to compute our fit residuals.
+
+    Returns
+    -------
+    chisq : jax.Array
+        The chi-squared of the model.
+    grad : jax.Array
+        The gradient of the parameters at there current values.
+        This is a `(npar,)` array.
+    """
+    token = mpi4jax.barrier(comm=todvec.comm)
+    npar = len(model.pars)
+    chisq = jnp.array(0)
+    grad = jnp.zeros(npar)
+    for tod in todvec:
+        x = tod.x * wu.rad_to_arcsec
+        y = tod.y * wu.rad_to_arcsec
+
+        pred_tod, grad_tod = model.to_tod_grad(x, y)
+        ndet, nsamp = tod.shape
+
+        resid = tod.data - pred_tod
+        resid_filt = tod.noise.apply_noise(resid)
+        chisq += jnp.sum(resid * resid_filt)
+
+        grad_filt = jnp.zeros_like(grad_tod)
+        for i in range(npar):
+            grad_filt = grad_filt.at[i].set(tod.noise.apply_noise(grad_tod.at[i].get()))
+        grad_filt = jnp.reshape(grad_filt, (npar, ndet * nsamp))
+        grad_tod = jnp.reshape(grad_tod, (npar, ndet * nsamp))
+        resid = jnp.reshape(resid, (ndet * nsamp,))
+
+        grad = grad.at[:].add(jnp.dot(grad_filt, jnp.transpose(resid)))
+
+    chisq, token = mpi4jax.allreduce(chisq, MPI.SUM, comm=todvec.comm, token=token)
+    grad, token = mpi4jax.allreduce(grad, MPI.SUM, comm=todvec.comm, token=token)
+    _ = mpi4jax.barrier(comm=todvec.comm, token=token)
+
+    return chisq, grad
 
 
 @jax.jit
@@ -304,13 +406,128 @@ def fit_tods(
     return model, i, delta_chisq
 
 
+def hmc(
+    params: jax.Array,
+    log_prob: Callable[[jax.Array], jax.Array],
+    log_prob_grad: Callable[[jax.Array], jax.Array],
+    num_steps: int,
+    num_leaps: int,
+    step_size: float,
+    comm: MPI.Intracomm,
+    key: jax.Array,
+) -> jax.Array:
+    """
+    Runs Hamilonian Monte Carlo using a leapfrog integrator to approximate Hamilonian dynamics.
+    This is a naive implementaion that will be replaced in the future.
+
+    The parallelism model employed here is different that most samplers where each task runs
+    a subset of the chain, instead since the rest of WITCH employs a model where the data is
+    distributed across tasks we do that here as well.
+    In this model the chain evolves simultaneously in all tasks,
+    but only rank 0 actually stores the chain.
+
+    Parameters
+    ----------
+    params : jax.Array
+        The initial parameters to start the chain at.
+    log_prob : Callable[[jax.Array], jax.Array]
+        Function that returns the log probability of the model
+        for a given set of params. This should take `params` as its
+        first arguments, all other arguments should be fixed ahead of time
+        (ie: using `functools.partial`).
+    log_prob_grad : Callable[[jax.Array], jax.Array]
+        Function that returns the gradient log probability of the model
+        for a given set of params. This should take `params` as its
+        first arguments, all other arguments should be fixed ahead of time
+        (ie: using `functools.partial`). The returned gradient should have
+        shape `(len(params),)`.
+    num_steps : int
+        The number of steps to run the chain for.
+    num_leaps : int
+        The number of leapfrog steps to run at each step of the chain.
+    step_size : float
+        The step size to use.
+        At each leapfrog step the parameters will evolve by `step_size`*`momentum`.
+    comm : MPI.Intracomm
+        The MPI comm object to use.
+
+    Returns
+    -------
+    chain : jax.Array
+        The chain of samples.
+        Will have shape `(num_steps, len(params))` in the rank 0 task.
+        Note that on tasks with rank other than 0 the actual
+        chain is not returned, instead a dummy array of size `(0,)` is
+        returned.
+    """
+    rank = comm.Get_rank()
+    vnorm = jax.vmap(
+        partial(jax.random.normal, shape=params[0].shape, dtype=params.dtype)
+    )
+    npar = len(params)
+    ones = jnp.ones(npar, dtype=bool)
+
+    @jax.jit
+    def _leap(_, args):
+        params, momentum = args
+        momentum = momentum.at[:].add(0.5 * step_size * log_prob_grad(params))  # kick
+        params = params.at[:].add(step_size * momentum)  # drift
+        momentum = momentum.at[:].add(0.5 * step_size * log_prob_grad(params))  # kick
+
+        return params, momentum
+
+    @jax.jit
+    def _sample(i, key, params):
+        token = mpi4jax.barrier(comm=comm)
+        key, token = mpi4jax.bcast(key, 0, comm=comm, token=token)
+        key, uniform_key = jax.random.split(key, 2)
+
+        # generate random momentum
+        momentum = vnorm(jax.random.split(key, npar))
+        new_params, new_momentum = jax.lax.fori_loop(
+            0, num_leaps, _leap, (params, momentum)
+        )
+
+        # MH correction
+        dpe = log_prob(new_params) - log_prob(params)
+        dke = -0.5 * (jnp.sum(new_momentum**2) - jnp.sum(momentum**2))
+        log_accept = dke + dpe
+        accept_prob = jnp.minimum(jnp.exp(log_accept), 1)
+        accept = jax.random.uniform(uniform_key) < accept_prob
+        params = jax.lax.select(accept * ones, new_params, params)
+
+        return key, params, accept_prob
+
+    t0 = time.time()
+    l_sample = _sample.lower(0, key, params)
+    c_sample = l_sample.compile()
+    t1 = time.time()
+    if rank == 0:
+        print(f"Compiled MC sample function in {t1-t0} s")
+
+    chain = []
+    accept_prob = []
+    for i in tqdm(range(num_steps), disable=(rank != 0)):
+        key, params, prob = c_sample(i, key, params)
+        if rank == 0:
+            chain += [params]
+            accept_prob += [prob]
+    if rank == 0:
+        chain = jnp.vstack(chain)
+        accept_prob = jnp.array(accept_prob)
+        print(f"Accepted {accept_prob.mean():.2%} of samples")
+    else:
+        chain = jnp.zeros(0)
+    return chain
+
+
 def run_mcmc(
     model: Model,
     todvec: TODVec,
     num_steps: int = 5000,
-    num_walkers: int = 10,
+    num_leaps: int = 10,
+    step_size: float = 0.02,
     sample_which: int = -1,
-    rescale: float = 1e4,
 ) -> tuple[Model, jax.Array]:
     """
     Run MCMC using the `emcee` package to estimate the posterior for our model.
@@ -329,13 +546,13 @@ def run_mcmc(
         We expect that all parameters in this model have priors defined.
     todvec : TODVec
         The TODs to compute the likelihood of the model with.
-    num_steps : int
+    num_steps : int, default: 5000
         The number of steps to run MCMC for.
-    num_walkers : int
-        The number of walkers to use.
-        If this is less than 2.1 times the number of
-        parameters in the model then 2.1 times the number
-        of parameters in the model is used.
+    num_leaps: int, default: 10
+        The number of leapfrog steps to take at each sample.
+    step_size, default: .02
+        The step size to use in the leapfrog algorithm.
+        This should be tuned to get an acceptance fraction of ~.65.
     sample_which : int, default: -1,
         Sets which parameters to sample.
         If this is >= 0 then we will sample which ever parameters were
@@ -344,10 +561,6 @@ def run_mcmc(
         in the last round of fitting.
         If this is -2 then any parameters that were ever fit will be sampled.
         If this is <= -3 or >= `model.n_rounds` then all parameters are sampled.
-    rescale : float, default: 1e4
-        Factor to rescale chi-squared by.
-        This is a temporary fudge factor until the root issue is addressed.
-        It will be removed in a later release.
 
     Returns
     -------
@@ -380,101 +593,97 @@ def run_mcmc(
         to_fit = model.to_fit_ever
     else:
         to_fit = jnp.ones_like(model.to_fit_ever, dtype=bool)
+    to_fit = jnp.array(to_fit)
     model = model.add_round(jnp.array(to_fit))
 
     init_pars = jnp.array(model.pars)
     init_errs = jnp.zeros_like(model.pars)
     final_pars = init_pars.copy()
     final_errs = init_errs.copy()
-    to_fit = model.to_fit_ever
-    npar = int(jnp.sum(to_fit))
+    npar = int(jnp.sum(jnp.array(to_fit)))
 
     prior_l, prior_u = model.priors
     scale = (jnp.abs(prior_l) + jnp.abs(prior_u)) / 2.0
     scale = jnp.where(scale == 0, 1, scale)
     init_pars = init_pars.at[:].multiply(1.0 / scale)
 
-    num_walkers = max(num_walkers, int(2.1 * len(init_pars)))
-
-    def _is_inf(log_prior, pars, token, model):
-        _ = (log_prior, pars, token, model)
+    def _is_inf(pars, token, model, scale):
+        _ = (pars, token, model, scale, to_fit)
         return -1 * jnp.inf
 
-    def _not_inf(log_prior, pars, token, model):
+    def _not_inf(pars, token, model, scale):
         pars, token = mpi4jax.bcast(pars, 0, comm=todvec.comm, token=token)
         temp_model = model.update(pars, init_errs, model.chisq)
-        log_like = -0.5 * get_chisq(temp_model, todvec) * rescale
-        run = jnp.array(True)
-        _ = mpi4jax.bcast(run, 0, comm=todvec.comm, token=token)
-        return log_like + log_prior
+        log_like = -0.5 * get_chisq(temp_model, todvec)
+        return log_like
 
     @jax.jit
-    def _log_prob(pars, model=model, init_pars=init_pars, scale=scale, to_fit=to_fit):
-        full_pars = init_pars.at[to_fit].set(pars)
+    def _log_prob(pars, model=model, init_pars=init_pars, scale=scale):
+        full_pars = init_pars.at[model.to_fit].set(pars)
         full_pars = full_pars.at[:].multiply(scale)
-        run = jnp.array(True)
-        _, token = mpi4jax.bcast(run, 0, comm=todvec.comm)
-        _, in_bounds = _prior_pars_fit(model.priors, full_pars, to_fit)
-        log_prior = jnp.sum(jnp.where(in_bounds.at[to_fit].get(), 0, -1 * jnp.inf))
+        _, in_bounds = _prior_pars_fit(model.priors, full_pars, jnp.array(model.to_fit))
+        log_prior = jnp.sum(
+            jnp.where(in_bounds.at[model.to_fit].get(), 0, -1 * jnp.inf)
+        )
+        token = 0
         return jax.lax.cond(
             jnp.isfinite(log_prior),
             _not_inf,
             _is_inf,
-            log_prior,
             full_pars,
             token,
             model,
+            scale,
         )
 
-    run = jnp.array(True)
+    def _is_inf_grad(pars, token, model, scale):
+        _ = (pars, token, model, scale, to_fit)
+        return jnp.inf * jnp.ones_like(pars)
+
+    def _not_inf_grad(pars, token, model, scale):
+        pars, token = mpi4jax.bcast(pars, 0, comm=todvec.comm, token=token)
+        temp_model = model.update(pars, init_errs, model.chisq)
+        grad = get_grad(temp_model, todvec)
+        grad = grad.at[:].multiply(scale)
+        return grad.at[model.to_fit].get().ravel()
+
+    @jax.jit
+    def _log_prob_grad(pars, model=model, init_pars=init_pars, scale=scale):
+        full_pars = init_pars.at[model.to_fit].set(pars)
+        full_pars = full_pars.at[:].multiply(scale)
+        _, in_bounds = _prior_pars_fit(model.priors, full_pars, jnp.array(model.to_fit))
+        log_prior = jnp.sum(
+            jnp.where(in_bounds.at[model.to_fit].get(), 0, -1 * jnp.inf)
+        )
+        token = 0
+        return jax.lax.cond(
+            jnp.isfinite(log_prior),
+            _not_inf_grad,
+            _is_inf_grad,
+            full_pars,
+            token,
+            model,
+            scale,
+        )
+
+    key = jax.random.PRNGKey(0)
+    key, token = mpi4jax.bcast(key, 0, comm=todvec.comm, token=token)
+    chain = hmc(
+        init_pars,
+        _log_prob,
+        _log_prob_grad,
+        num_steps=num_steps,
+        num_leaps=num_leaps,
+        step_size=step_size,
+        comm=todvec.comm,
+        key=key,
+    )
+    flat_samples = chain.at[:].multiply(scale.at[to_fit].get())
     if rank == 0:
-        key1 = jax.random.PRNGKey(0)
-        pos = 1e-5 * jax.random.normal(key1, shape=(num_walkers, npar))
-        pos = pos.at[:].add(init_pars.at[to_fit].get())
-        sampler = emcee.EnsembleSampler(
-            num_walkers,
-            npar,
-            _log_prob,
-        )
-
-        # Burn in
-        state = sampler.run_mcmc(
-            pos, max(50, min(50, int(num_steps / 10))), progress=True
-        )
-        sampler.reset()
-
-        # Run for real
-        sampler.run_mcmc(state, num_steps, progress=True)
-        run = jnp.array(False)
-        run, token = mpi4jax.bcast(run, 0, comm=todvec.comm, token=token)
-        tau = 0
-        if num_steps > 100:
-            try:
-                tau = int(np.max(sampler.get_autocorr_time()))
-            except emcee.autocorr.AutocorrError:
-                tau = int(num_steps / 50)
-        flat_samples = jnp.array(
-            sampler.get_chain(discard=2 * tau, thin=max(1, int(tau / 2)), flat=True)
-            * scale.at[to_fit].get()
-        )
         final_pars = final_pars.at[to_fit].set(jnp.median(flat_samples, axis=0).ravel())
         final_errs = final_errs.at[to_fit].set(jnp.std(flat_samples, axis=0).ravel())
-        final_pars, token = mpi4jax.bcast(final_pars, 0, comm=todvec.comm, token=token)
-        final_errs, _ = mpi4jax.bcast(final_errs, 0, comm=todvec.comm, token=token)
-    else:
-        pars = init_pars.copy()
-        flat_samples = jnp.zeros(1)
-        while run:
-            run, token = mpi4jax.bcast(run, 0, comm=todvec.comm, token=token)
-            if not run:
-                break
-            pars, token = mpi4jax.bcast(pars, 0, comm=todvec.comm, token=token)
-            temp_model = model.update(pars, init_errs, model.chisq)
-            _ = get_chisq(temp_model, todvec)
-            run, token = mpi4jax.bcast(run, 0, comm=todvec.comm, token=token)
-        final_pars, token = mpi4jax.bcast(final_pars, 0, comm=todvec.comm, token=token)
-        final_errs, _ = mpi4jax.bcast(final_errs, 0, comm=todvec.comm, token=token)
-
+    final_pars, token = mpi4jax.bcast(final_pars, 0, comm=todvec.comm, token=token)
+    final_errs, _ = mpi4jax.bcast(final_errs, 0, comm=todvec.comm, token=token)
     model = model.update(
         final_pars.block_until_ready(), final_errs.block_until_ready(), model.chisq
     )


### PR DESCRIPTION
This works and is integrated into `witcher` (see the `mcmc_check.yaml` in `unit_tests`) but is not optimized to run on GPUs, Punting the performance updates to a later date since we can do a MS075 like model with 5000 steps and 120 walkers in ~20 hours without MPI so should be usable for people who need it now.

This relies on #107 and #108 to be merged first.