### PR TITLE
fix: add post-proc loop when fit==false

### DIFF
--- a/witch/fitter.py
+++ b/witch/fitter.py
@@ -683,4 +683,8 @@ def main():
                     dset_name, cfg, dataset.datavec, nonpara_model, dataset.info
                 )
 
+    else:
+        for dset_name, dataset, model in zip(dset_names, datasets, models):
+            dataset.postfit(dset_name, cfg, dataset.datavec, model, dataset.info)
+
     print_once("Outputs can be found in", outdir)


### PR DESCRIPTION
Fixes issue [168](https://github.com/MUSTANG-SZ/WITCH/issues/168). Just needed to add an `else` block to the `postproc` loop for when `fit==False`.