### PR TITLE
Add LoS integration tests for structure.py

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,29 @@
+name: Tests
+
+
+on:
+  push:
+    branches: [main]
+  pull_request: 
+
+
+jobs: 
+  structure-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with: 
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install jax jaxlib numpy scipy astropy pytest
+          pip install --no-deps -e .
+
+      - name: Run structure tests
+        run: |
+          python -m pytest tests/test_structure.py -v

--- a/tests/analytical_2d.py
+++ b/tests/analytical_2d.py
@@ -54,3 +54,50 @@ def gaussian_2d_integrated(
     amp_integrated = amp * jnp.sqrt(2 * jnp.pi) * sigma
 
     return amp_integrated * jnp.exp(-r_sq / (2 * sigma**2))
+
+
+def cylindrical_beta_2d_analytical(
+    dx: float,
+    dy: float,
+    dz: float,
+    L: float,
+    theta: float,
+    phi: float,
+    P0: float,
+    r_c: float,
+    beta: float,
+    xyz: tuple,
+) -> jnp.ndarray:
+    """
+    Wrapper around structure.cylindrical_beta_2d for use in tests.
+    phi=0 means cylinder is along line of sight, sec(phi)=1.
+    """
+    from witch import structure
+
+    return structure.cylindrical_beta_2d(dx, dy, dz, L, theta, phi, P0, r_c, beta, xyz)
+
+
+def sph_isobeta_2d_slice(
+    dx: float,
+    dy: float,
+    r: float,
+    beta: float,
+    amp: float,
+    xyz: tuple,
+    z_val: float = 0.0,
+) -> jnp.ndarray:
+    """
+    3D sph_isobeta evaluated at a given z slice.
+    structure.sph_isobeta: amp * (1 + r²)^(-3β/2)
+    where r is already scaled by transform_grid with scale=r.
+    So at z=z_val: amp * (1 + R²/r² + z_val²/r²)^(-3β/2)
+    """
+    x, y, *_ = transform_grid(dx, dy, 0, 1, 1, 1, 0, xyz)
+    x_2d = x[..., 0]
+    y_2d = y[..., 0]
+
+    r_sq = x_2d**2 + y_2d**2
+    rr = 1 + r_sq / r**2 + z_val**2 / r**2
+    power = -1.5 * beta
+
+    return amp * rr**power

--- a/tests/analytical_2d.py
+++ b/tests/analytical_2d.py
@@ -84,3 +84,25 @@ def cylindrical_beta_2d_analytical(
     from witch import structure
 
     return structure.cylindrical_beta_2d(dx, dy, dz, L, theta, phi, P0, r_c, beta, xyz)
+
+
+def add_uniform_2d_analytical(
+    dx: float,
+    dy: float,
+    r: float,
+    amp: float,
+    xyz: tuple,
+) -> jnp.ndarray:
+    """
+    Closed-form 2D result of the uniform ellipsoid contribution along z.
+    For a sphere of radius r, the LoS integral of the (1+amp)*pressure - pressure = amp*pressure term is just amp * pressure * chord_length.
+    Chord length at projected radius R is 2*sqrt(r^2 - R^2) for R < r, else 0.
+    """
+    x, y, *_ = transform_grid(dx, dy, 0, 1, 1, 1, 0, xyz)
+    x_2d = np.array(x[..., 0])
+    y_2d = np.array(y[..., 0])
+
+    R_sq = x_2d**2 + y_2d**2
+    chord = np.where(R_sq < r**2, 2 * np.sqrt(np.maximum(r**2 - R_sq, 0.0)), 0.0)
+
+    return jnp.array(amp * chord)

--- a/tests/analytical_2d.py
+++ b/tests/analytical_2d.py
@@ -1,0 +1,56 @@
+"""
+Analytical 2D solutions for structure profiles
+"""
+
+import jax.numpy as jnp
+import numpy as np
+from scipy.special import gamma
+
+from witch.grid import transform_grid
+
+
+def isobeta_2d_analytical(
+    dx: float,
+    dy: float,
+    theta: float,
+    beta: float,
+    amp: float,
+    xyz: tuple,
+    z_val: float = 0.0,  # actual z coordinate of the slice
+) -> jnp.ndarray:
+    """
+    3D isobeta evaluated at a given z slice.
+    Matches structure.isobeta: amp * (1 + R²/θ² + z²/θ²)^(-3β/2)
+    """
+    x, y, *_ = transform_grid(dx, dy, 0, 1, 1, 1, 0, xyz)
+    x_2d = x[..., 0]
+    y_2d = y[..., 0]
+
+    r_sq = x_2d**2 + y_2d**2
+    rr = 1 + r_sq / theta**2 + z_val**2 / theta**2
+    power = -1.5 * beta
+
+    return amp * rr**power
+
+
+def gaussian_2d_integrated(
+    dx: float,
+    dy: float,
+    sigma: float,
+    amp: float,
+    xyz: tuple,
+) -> jnp.ndarray:
+    """
+    Analytical result of integrating 3D gaussian along z.
+
+    For P(x,y,z) = amp * exp(-(x²+y²+z²)/(2σ²))
+    Integrating along z: amp * sqrt(2π) * σ * exp(-(x²+y²)/(2σ²))
+    """
+    x, y, *_ = transform_grid(dx, dy, 0, 1, 1, 1, 0, xyz)
+    x_2d = x[..., 0]
+    y_2d = y[..., 0]
+
+    r_sq = x_2d**2 + y_2d**2
+    amp_integrated = amp * jnp.sqrt(2 * jnp.pi) * sigma
+
+    return amp_integrated * jnp.exp(-r_sq / (2 * sigma**2))

--- a/tests/analytical_2d.py
+++ b/tests/analytical_2d.py
@@ -16,21 +16,30 @@ def isobeta_2d_analytical(
     beta: float,
     amp: float,
     xyz: tuple,
-    z_val: float = 0.0,  # actual z coordinate of the slice
 ) -> jnp.ndarray:
     """
-    3D isobeta evaluated at a given z slice.
-    Matches structure.isobeta: amp * (1 + R²/θ² + z²/θ²)^(-3β/2)
+    Definite integral of 3D isobeta from -r_map to +r_map along z.
+
+    ∫_{-z_max}^{z_max} amp * (1 + R²/θ² + z²/θ²)^(-3β/2) dz
+    = 2 * amp * θ * a^(1-3β) * T * 2F1(1/2, 3β/2; 3/2; -T²)
+
+    where a = sqrt(1 + R²/θ²) and T = z_max / (θ * a)
     """
-    x, y, *_ = transform_grid(dx, dy, 0, 1, 1, 1, 0, xyz)
-    x_2d = x[..., 0]
-    y_2d = y[..., 0]
+    from scipy.special import hyp2f1
 
+    x, y, z_arr, *_ = transform_grid(dx, dy, 0, 1, 1, 1, 0, xyz)
+    x_2d = np.array(x[..., 0])
+    y_2d = np.array(y[..., 0])
+
+    z_max = float(np.abs(z_arr[0, 0, -1]))
+
+    n = 1.5 * beta
     r_sq = x_2d**2 + y_2d**2
-    rr = 1 + r_sq / theta**2 + z_val**2 / theta**2
-    power = -1.5 * beta
+    a = np.sqrt(1 + r_sq / theta**2)
+    T = z_max / (theta * a)
 
-    return amp * rr**power
+    result = 2 * amp * theta * a ** (1 - 2 * n) * T * hyp2f1(0.5, n, 1.5, -(T**2))
+    return jnp.array(result)
 
 
 def gaussian_2d_integrated(
@@ -75,29 +84,3 @@ def cylindrical_beta_2d_analytical(
     from witch import structure
 
     return structure.cylindrical_beta_2d(dx, dy, dz, L, theta, phi, P0, r_c, beta, xyz)
-
-
-def sph_isobeta_2d_slice(
-    dx: float,
-    dy: float,
-    r: float,
-    beta: float,
-    amp: float,
-    xyz: tuple,
-    z_val: float = 0.0,
-) -> jnp.ndarray:
-    """
-    3D sph_isobeta evaluated at a given z slice.
-    structure.sph_isobeta: amp * (1 + r²)^(-3β/2)
-    where r is already scaled by transform_grid with scale=r.
-    So at z=z_val: amp * (1 + R²/r² + z_val²/r²)^(-3β/2)
-    """
-    x, y, *_ = transform_grid(dx, dy, 0, 1, 1, 1, 0, xyz)
-    x_2d = x[..., 0]
-    y_2d = y[..., 0]
-
-    r_sq = x_2d**2 + y_2d**2
-    rr = 1 + r_sq / r**2 + z_val**2 / r**2
-    power = -1.5 * beta
-
-    return amp * rr**power

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,119 @@
+"""
+Pytest configuration and shared fixtures for WITCH tests.
+Reference outputs for structures without closed forms are stored in pytest cache and tracked in the repository so anyone can pull and run tests against a known-good state.
+"""
+
+import numpy as np
+import pytest
+
+from witch import grid, structure
+
+# ---------------------------------------------------------------------------
+# Shared grid fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def test_grid():
+    """
+    Standard grid for most tests.
+    """
+    r_map = 60.0
+    dr = 2.0
+    dz = 2.0
+    xyz = grid.make_grid(r_map, dr, dr, dz, 0.0, 0.0)
+    return xyz, dz
+
+
+@pytest.fixture
+def wide_grid():
+    """
+    Wide grid needed for slowly-decaying profiles (power-law tails).
+    """
+    r_map = 180.0
+    dr = 2.0
+    dz = 2.0
+    xyz = grid.make_grid(r_map, dr, dr, dz, 0.0, 0.0)
+    return xyz, dz
+
+
+# ---------------------------------------------------------------------------
+# Reference output cache fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def gnfw_reference(request):
+    """
+    Reference output for gnfw model.]
+    """
+    cache_key = "structure/gnfw_reference"
+    cached = request.config.cache.get(cache_key, None)
+
+    if cached is not None:
+        return np.array(cached)
+
+    # Compute reference output
+    r_map = 60.0
+    dr = 2.0
+    dz = 2.0
+    xyz = grid.make_grid(r_map, dr, dr, dz, 0.0, 0.0)
+
+    model = structure.gnfw(
+        dx=0.0,
+        dy=0.0,
+        dz=0.0,
+        r=1.0,
+        P0=8.403,
+        c500=1.177,
+        m500=1e15,
+        gamma=0.3081,
+        alpha=1.0510,
+        beta=5.4905,
+        z=0.5,
+        xyz=xyz,
+    )
+
+    # Integrate along z to get 2D map
+    model_2d = np.array(np.sum(model, axis=2) * dz)
+
+    request.config.cache.set(cache_key, model_2d.tolist())
+    return model_2d
+
+
+@pytest.fixture(scope="session")
+def a10_reference(request):
+    """
+    Reference output for a10 model.
+    """
+    cache_key = "structure/a10_reference"
+    cached = request.config.cache.get(cache_key, None)
+
+    if cached is not None:
+        return np.array(cached)
+
+    # Compute reference output using Arnaud 2010 best-fit parameters
+    r_map = 60.0
+    dr = 2.0
+    dz = 2.0
+    xyz = grid.make_grid(r_map, dr, dr, dz, 0.0, 0.0)
+
+    model = structure.a10(
+        dx=0.0,
+        dy=0.0,
+        dz=0.0,
+        theta=1.0,
+        P0=8.403,
+        c500=1.177,
+        m500=1e15,
+        gamma=0.3081,
+        alpha=1.0510,
+        beta=5.4905,
+        z=0.5,
+        xyz=xyz,
+    )
+
+    model_2d = np.array(np.sum(model, axis=2) * dz)
+
+    request.config.cache.set(cache_key, model_2d.tolist())
+    return model_2d

--- a/tests/test_checkpointing.py
+++ b/tests/test_checkpointing.py
@@ -13,8 +13,12 @@ import dill as pk
 import numpy as np
 import pytest
 
-sys.modules["mpi4py"] = MagicMock()
-sys.modules["mpi4py.MPI"] = MagicMock()
+# Only mock mpi4py if it isn't actually available
+try:
+    import mpi4py
+except:
+    sys.modules["mpi4py"] = MagicMock()
+    sys.modules["mpi4py.MPI"] = MagicMock()
 
 from witch.fitter import _read_checkpoint, _read_model, _save_checkpoint
 

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -6,7 +6,11 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
-from tests.analytical_2d import gaussian_2d_integrated, isobeta_2d_analytical
+from tests.analytical_2d import (
+    gaussian_2d_integrated,
+    isobeta_2d_analytical,
+    sph_isobeta_2d_slice,
+)
 from witch import grid, structure
 
 
@@ -24,8 +28,10 @@ class TestStructureAnalytical:
 
     @pytest.fixture
     def wide_grid(self):
-        """Wider z-extent grid for gaussian test (needs to capture tails)"""
-        r_map = 150.0  # ±150 arcsec = ±15σ for sigma=10, plenty of coverage
+        """
+        wide z-extent grid needed for the slowly decaying profiles
+        """
+        r_map = 300.0  # cylindrical_beta needs a lot of z extent
         dr = 2.0
         dz = 2.0
         xyz = grid.make_grid(r_map, dr, dr, dz, 0.0, 0.0)
@@ -34,9 +40,8 @@ class TestStructureAnalytical:
     def test_isobeta_spherical_vs_analytical_2d(self, test_grid):
         """
         Test isobeta 2D analytical formula matches minkasi C code.
-        We compare structure.isobeta (3D) at a single z-slice against
-        the minkasi closed-form 2D result.
-        Note: full z-integration is impractical due to very slow power-law decay.
+        Compare structure.isobeta (3D) at a single z-slice against the minkasi closed-form 2D result.
+        full z-integration is impractical due to very slow power-law decay.
         """
         xyz, dz = test_grid
         dx, dy, dz_offset = 0.0, 0.0, 0.0
@@ -75,5 +80,54 @@ class TestStructureAnalytical:
         model_2d_from_3d = jnp.sum(model_3d, axis=2) * dz
 
         model_2d_analytical = gaussian_2d_integrated(dx, dy, sigma, amp, xyz)
+
+        assert np.allclose(model_2d_from_3d, model_2d_analytical, rtol=1e-2)
+
+    def test_sph_isobeta_vs_analytical_slice(self, test_grid):
+        """Test sph_isobeta 3D z-slice against analytical formula"""
+        xyz, dz = test_grid
+        dx, dy, dz_offset = 0.0, 0.0, 0.0
+        r = 10.0
+        beta = 0.7
+        amp = 1.0
+
+        model_3d = structure.sph_isobeta(dx, dy, dz_offset, r, 0.0, beta, amp, xyz)
+
+        z_vals = xyz[2][0, 0, :]
+        iz = int(jnp.argmin(jnp.abs(z_vals)))
+        z_actual = float(z_vals[iz])
+        model_2d_from_3d = model_3d[..., iz]
+
+        model_2d_analytical = sph_isobeta_2d_slice(
+            dx, dy, r, beta, amp, xyz, z_val=z_actual
+        )
+
+        assert np.allclose(model_2d_from_3d, model_2d_analytical, rtol=1e-2, atol=1e-5)
+
+    def test_cylindrical_beta_3d_vs_2d(self, wide_grid):
+        """
+        Test cylindrical_beta 3D integration along z against cylindrical_beta_2d.
+        Cylinder aligned along x-axis, phi=0 (no LoS tilt), so sec(phi)=1.
+        The 3D model integrates P0*(1 + (y²+z²)/r_c²)^(-3β/2) along z,
+        giving the same closed form as cylindrical_beta_2d.
+        """
+        xyz, dz = wide_grid
+        dx, dy, dz_offset = 0.0, 0.0, 0.0
+        L = 700.0  # so that cutoff never triggers within grid (bc > 2*r_map which equals 600)
+        theta = 0.0
+        phi = 0.0  # no tilt, sec(phi)=1
+        P0 = 1.0
+        r_c = 10.0
+        beta = 0.7
+
+        model_3d = structure.cylindrical_beta(
+            dx, dy, dz_offset, L, theta, P0, r_c, beta, xyz
+        )
+
+        model_2d_from_3d = jnp.sum(model_3d, axis=2) * dz
+
+        model_2d_analytical = structure.cylindrical_beta_2d(
+            dx, dy, dz_offset, L, theta, phi, P0, r_c, beta, xyz
+        )
 
         assert np.allclose(model_2d_from_3d, model_2d_analytical, rtol=1e-2)

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -90,7 +90,7 @@ class TestStructureAnalytical:
 
         assert np.allclose(model_2d_from_3d, model_2d_analytical, rtol=1e-2)
 
-    @pytest.mark.xfail(reason="Known bug in cylindrical_beta_2d: see GitHub issue")
+    @pytest.mark.xfail(reason="Known bug in cylindrical_beta_2d: see issue #178")
     def test_cylindrical_beta_3d_vs_2d(self, wide_grid):
         """
         Test cylindrical_beta 3D integration along z against cylindrical_beta_2d.
@@ -102,7 +102,7 @@ class TestStructureAnalytical:
         dx, dy, dz_offset = 0.0, 0.0, 0.0
         L = 700.0  # so that cutoff never triggers within grid (bc > 2*r_map which equals 600)
         theta = 0.0
-        phi = 0.0  # no tilt, sec(phi)=1
+        phi = 0.0
         P0 = 1.0
         r_c = 10.0
         beta = 0.7
@@ -120,7 +120,9 @@ class TestStructureAnalytical:
         assert np.allclose(model_2d_from_3d, model_2d_analytical, rtol=1e-2)
 
     def test_gnfw_matches_reference(self, test_grid, gnfw_reference):
-        """Test gnfw output matches cached reference."""
+        """
+        Test gnfw output matches cached reference.
+        """
         xyz, dz = test_grid
 
         model = structure.gnfw(
@@ -142,7 +144,9 @@ class TestStructureAnalytical:
         assert np.allclose(model_2d, gnfw_reference, rtol=1e-5)
 
     def test_a10_matches_reference(self, test_grid, a10_reference):
-        """Test a10 output matches cached reference."""
+        """
+        Test a10 output matches cached reference.
+        """
         xyz, dz = test_grid
 
         model = structure.a10(

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -1,0 +1,79 @@
+"""
+Unit tests for structure.py - testing 3D models against analytical 2D solutions
+"""
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from tests.analytical_2d import gaussian_2d_integrated, isobeta_2d_analytical
+from witch import grid, structure
+
+
+class TestStructureAnalytical:
+    """Test structures with closed-form 2D solutions"""
+
+    @pytest.fixture
+    def test_grid(self):
+        """Standard grid for most tests"""
+        r_map = 60.0
+        dr = 2.0
+        dz = 2.0
+        xyz = grid.make_grid(r_map, dr, dr, dz, 0.0, 0.0)
+        return xyz, dz
+
+    @pytest.fixture
+    def wide_grid(self):
+        """Wider z-extent grid for gaussian test (needs to capture tails)"""
+        r_map = 150.0  # ±150 arcsec = ±15σ for sigma=10, plenty of coverage
+        dr = 2.0
+        dz = 2.0
+        xyz = grid.make_grid(r_map, dr, dr, dz, 0.0, 0.0)
+        return xyz, dz
+
+    def test_isobeta_spherical_vs_analytical_2d(self, test_grid):
+        """
+        Test isobeta 2D analytical formula matches minkasi C code.
+        We compare structure.isobeta (3D) at a single z-slice against
+        the minkasi closed-form 2D result.
+        Note: full z-integration is impractical due to very slow power-law decay.
+        """
+        xyz, dz = test_grid
+        dx, dy, dz_offset = 0.0, 0.0, 0.0
+        theta_core = 10.0
+        beta = 0.7
+        amp = 1.0
+
+        # Get a single z=0 slice of the 3D model (center slice)
+        model_3d = structure.isobeta(
+            dx, dy, dz_offset, theta_core, theta_core, theta_core, 0.0, beta, amp, xyz
+        )
+        # Find the z slice closest to z=0
+        z_vals = xyz[2][0, 0, :]
+        iz = int(jnp.argmin(jnp.abs(z_vals)))
+        z_actual = float(z_vals[iz])
+        model_2d_from_3d = model_3d[..., iz]
+
+        # Minkasi closed-form 2D result at that z
+        model_2d_analytical = isobeta_2d_analytical(
+            dx, dy, theta_core, beta, amp, xyz, z_val=z_actual
+        )
+
+        assert np.allclose(model_2d_from_3d, model_2d_analytical, rtol=1e-2, atol=1e-5)
+
+    def test_gaussian_3d_vs_2d_integrated(self, wide_grid):
+        """Test 3D gaussian integration against analytical 2D gaussian"""
+        xyz, dz = wide_grid
+        dx, dy, dz_offset = 0.0, 0.0, 0.0
+        sigma = 10.0
+        amp = 1.0
+
+        model_3d = structure.egaussian(
+            dx, dy, dz_offset, 1.0, 1.0, 1.0, 0.0, sigma, amp, xyz
+        )
+
+        model_2d_from_3d = jnp.sum(model_3d, axis=2) * dz
+
+        model_2d_analytical = gaussian_2d_integrated(dx, dy, sigma, amp, xyz)
+
+        assert np.allclose(model_2d_from_3d, model_2d_analytical, rtol=1e-2)

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -6,11 +6,7 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
-from tests.analytical_2d import (
-    gaussian_2d_integrated,
-    isobeta_2d_analytical,
-    sph_isobeta_2d_slice,
-)
+from tests.analytical_2d import gaussian_2d_integrated, isobeta_2d_analytical
 from witch import grid, structure
 
 
@@ -37,34 +33,27 @@ class TestStructureAnalytical:
         xyz = grid.make_grid(r_map, dr, dr, dz, 0.0, 0.0)
         return xyz, dz
 
-    def test_isobeta_spherical_vs_analytical_2d(self, test_grid):
+    def test_isobeta_vs_analytical_2d(self, wide_grid):
         """
-        Test isobeta 2D analytical formula matches minkasi C code.
-        Compare structure.isobeta (3D) at a single z-slice against the minkasi closed-form 2D result.
-        full z-integration is impractical due to very slow power-law decay.
+        Test isobeta 3D numerical z-integration against closed-form 2D result.
+        Uses theta_core << r_map so the LoS integral converges on the grid.
+        (r_map=180 arcsec ~3arcmin, theta_core=10 arcsec per Jack's guidance)
         """
-        xyz, dz = test_grid
+        xyz, dz = wide_grid
         dx, dy, dz_offset = 0.0, 0.0, 0.0
-        theta_core = 10.0
+        theta_core = 10.0  # arcsec, well below r_map=180 arcsec
         beta = 0.7
         amp = 1.0
 
-        # Get a single z=0 slice of the 3D model (center slice)
         model_3d = structure.isobeta(
             dx, dy, dz_offset, theta_core, theta_core, theta_core, 0.0, beta, amp, xyz
         )
-        # Find the z slice closest to z=0
-        z_vals = xyz[2][0, 0, :]
-        iz = int(jnp.argmin(jnp.abs(z_vals)))
-        z_actual = float(z_vals[iz])
-        model_2d_from_3d = model_3d[..., iz]
 
-        # Minkasi closed-form 2D result at that z
-        model_2d_analytical = isobeta_2d_analytical(
-            dx, dy, theta_core, beta, amp, xyz, z_val=z_actual
-        )
+        model_2d_from_3d = jnp.sum(model_3d, axis=2) * dz
 
-        assert np.allclose(model_2d_from_3d, model_2d_analytical, rtol=1e-2, atol=1e-5)
+        model_2d_analytical = isobeta_2d_analytical(dx, dy, theta_core, beta, amp, xyz)
+
+        assert np.allclose(model_2d_from_3d, model_2d_analytical, rtol=1e-2)
 
     def test_gaussian_3d_vs_2d_integrated(self, wide_grid):
         """Test 3D gaussian integration against analytical 2D gaussian"""
@@ -83,9 +72,11 @@ class TestStructureAnalytical:
 
         assert np.allclose(model_2d_from_3d, model_2d_analytical, rtol=1e-2)
 
-    def test_sph_isobeta_vs_analytical_slice(self, test_grid):
-        """Test sph_isobeta 3D z-slice against analytical formula"""
-        xyz, dz = test_grid
+    def test_sph_isobeta_vs_analytical_2d(self, wide_grid):
+        """
+        Test sph_isobeta 3D numerical z-integration against closed-form 2D result.
+        """
+        xyz, dz = wide_grid
         dx, dy, dz_offset = 0.0, 0.0, 0.0
         r = 10.0
         beta = 0.7
@@ -93,17 +84,13 @@ class TestStructureAnalytical:
 
         model_3d = structure.sph_isobeta(dx, dy, dz_offset, r, 0.0, beta, amp, xyz)
 
-        z_vals = xyz[2][0, 0, :]
-        iz = int(jnp.argmin(jnp.abs(z_vals)))
-        z_actual = float(z_vals[iz])
-        model_2d_from_3d = model_3d[..., iz]
+        model_2d_from_3d = jnp.sum(model_3d, axis=2) * dz
 
-        model_2d_analytical = sph_isobeta_2d_slice(
-            dx, dy, r, beta, amp, xyz, z_val=z_actual
-        )
+        model_2d_analytical = isobeta_2d_analytical(dx, dy, r, beta, amp, xyz)
 
-        assert np.allclose(model_2d_from_3d, model_2d_analytical, rtol=1e-2, atol=1e-5)
+        assert np.allclose(model_2d_from_3d, model_2d_analytical, rtol=1e-2)
 
+    @pytest.mark.xfail(reason="Known bug in cylindrical_beta_2d: see GitHub issue")
     def test_cylindrical_beta_3d_vs_2d(self, wide_grid):
         """
         Test cylindrical_beta 3D integration along z against cylindrical_beta_2d.
@@ -131,3 +118,47 @@ class TestStructureAnalytical:
         )
 
         assert np.allclose(model_2d_from_3d, model_2d_analytical, rtol=1e-2)
+
+    def test_gnfw_matches_reference(self, test_grid, gnfw_reference):
+        """Test gnfw output matches cached reference."""
+        xyz, dz = test_grid
+
+        model = structure.gnfw(
+            dx=0.0,
+            dy=0.0,
+            dz=0.0,
+            r=1.0,
+            P0=8.403,
+            c500=1.177,
+            m500=1e15,
+            gamma=0.3081,
+            alpha=1.0510,
+            beta=5.4905,
+            z=0.5,
+            xyz=xyz,
+        )
+        model_2d = jnp.sum(model, axis=2) * dz
+
+        assert np.allclose(model_2d, gnfw_reference, rtol=1e-5)
+
+    def test_a10_matches_reference(self, test_grid, a10_reference):
+        """Test a10 output matches cached reference."""
+        xyz, dz = test_grid
+
+        model = structure.a10(
+            dx=0.0,
+            dy=0.0,
+            dz=0.0,
+            theta=1.0,
+            P0=8.403,
+            c500=1.177,
+            m500=1e15,
+            gamma=0.3081,
+            alpha=1.0510,
+            beta=5.4905,
+            z=0.5,
+            xyz=xyz,
+        )
+        model_2d = jnp.sum(model, axis=2) * dz
+
+        assert np.allclose(model_2d, a10_reference, rtol=1e-5)

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -6,7 +6,11 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
-from tests.analytical_2d import gaussian_2d_integrated, isobeta_2d_analytical
+from tests.analytical_2d import (
+    add_uniform_2d_analytical,
+    gaussian_2d_integrated,
+    isobeta_2d_analytical,
+)
 from witch import grid, structure
 
 
@@ -166,3 +170,30 @@ class TestStructureAnalytical:
         model_2d = jnp.sum(model, axis=2) * dz
 
         assert np.allclose(model_2d, a10_reference, rtol=1e-5)
+
+    def test_add_uniform_vs_analytical_2d(self):
+        """
+        Test add_uniform 3D integration against closed-form 2D result.
+        Uses a fine grid to minimize boundary discretization error.
+        """
+        dr = 0.5  # finer resolution reduces boundary pixel error
+        dz = 0.5
+        r_map = 60.0
+        xyz = grid.make_grid(r_map, dr, dr, dz, 0.0, 0.0)
+
+        dx, dy, dz_offset = 0.0, 0.0, 0.0
+        r = 20.0
+        amp = 2.0
+
+        n = xyz[0].shape[0]
+        pressure = jnp.ones((n, n, n))
+
+        model_3d = structure.add_uniform(
+            pressure, xyz, dx, dy, dz_offset, r, r, r, 0.0, amp
+        )
+
+        diff_2d = jnp.sum(model_3d - pressure, axis=2) * dz
+
+        model_2d_analytical = add_uniform_2d_analytical(dx, dy, r, amp, xyz)
+
+        assert np.allclose(diff_2d, model_2d_analytical, rtol=1e-2, atol=1.0)


### PR DESCRIPTION
Adds unit tests for structure.py comparing numerical line-of-sight 3D models with closed form 2D analytical solutions.

Tests added:
- "test_isobeta_vs_analytical_2d": exact definite integral comparison using "scipy.special.hyp2f1"
- test_sph_isobeta_vs_analytical_2d": same approach as isobeta
- "test_gaussian_3d_vs_2d_integrated": closed-form Gaussian LoS integral
- "test_cylindrical_beta_3d_vs_2d": marked xfail and waiting for fix for #178 
- "test_gnfw_matches_reference": pytest cache reference output
- "test_a10_matches_reference": pytest cache reference output
- "test_add_uniform_vs_analytical_2d": closed form chord length integral