### PR TITLE
fix: clean up extraneous cov return in run_lmfit

### DIFF
--- a/witch/fitter.py
+++ b/witch/fitter.py
@@ -370,7 +370,7 @@ def _run_fit(
     to_fit = np.array(metamodel.to_fit)
     print_once(f"Starting round {r+1} of fitting with {np.sum(to_fit)} pars free")
     t1 = time.time()
-    metamodel, i, delta_chisq, cov = run_lmfit(
+    metamodel, i, delta_chisq = run_lmfit(
         metamodel,
         eval(str(cfg["fitting"].get("maxiter", "10"))),
         eval(str(cfg["fitting"].get("chitol", "1e-5"))),

--- a/witch/fitting.py
+++ b/witch/fitting.py
@@ -224,14 +224,13 @@ def run_lmfit(
         pars=pars, errs=metamodel.errs, cov=metamodel.cov, chisq=metamodel.chisq
     )
     _, grad, curve = joint_objective(metamodel, True, True, True)
-    cov = invscale(curve, do_invsafe=True)
     i, delta_chisq, _, metamodel, cov, *_ = jax.lax.while_loop(
         _cond_func,
         _body_func,
         (0, jnp.astype(jnp.inf, jnp.float32), zero.copy(), metamodel, cov, curve, grad),
     )
 
-    return metamodel, i, delta_chisq, cov
+    return metamodel, i, delta_chisq
 
 
 def hmc(


### PR DESCRIPTION
Cleans up extra cov return in `run_lmfit` that's no longer needed as cov is stored inside `metamodel`.