### PR TITLE
feat: add MCMC checkpointing using a chunked run_mcmc loop (issue #173)

### DIFF
--- a/witch/fitter.py
+++ b/witch/fitter.py
@@ -430,6 +430,7 @@ def _run_fit(
     return metamodel
 
 
+"""
 def _mcmc_checkpoint_callback(
     updated_metamodel, callback_state, checkpoint_interval, ckpt_dir, nonpara, cfg
 ):
@@ -448,6 +449,7 @@ def _mcmc_checkpoint_callback(
             step_num=step,
         )
         print_once(f"[checkpoint] Saved MCMC checkpoint at step {step} -> {ckpt_path}")
+"""
 
 
 def _run_mcmc(cfg, metamodel, nonpara=False):
@@ -455,10 +457,126 @@ def _run_mcmc(cfg, metamodel, nonpara=False):
     init_pars = np.array(metamodel.parameters.copy())
 
     # Checkpoint settings
-    checkpoint_interval = int(cfg["mcmc"].get("checkpoint_interval", 200))
+    total_steps = int(cfg["mcmc"].get("num_steps", 5000))
+    chunk_size = int(cfg["mcmc"].get("checkpoint_interval", 200))
     ckpt_dir = os.path.join(cfg["outdir"], "checkpoints")
     os.makedirs(ckpt_dir, exist_ok=True)
 
+    # Resume from an existing MCMC checkpoint if requested
+    resume_state = None
+    all_samples = None
+    steps_done = 0
+    load = cfg.get("load_progress", 0)
+    if load != 0:
+        mcmc_ckpts = []
+        for f in os.listdir(ckpt_dir):
+            if f.startswith("mcmc_step_") and (("nonpara" in f) == nonpara):
+                mcmc_ckpts.append(f)
+        if len(mcmc_ckpts) > 0:
+            latest = sorted(
+                mcmc_ckpts, key=lambda x: int(x.split("_")[2].split(".")[0])
+            )[-1]
+            load_path = os.path.join(ckpt_dir, latest)
+            print_once(f"[resume] Loading MCMC checkpoint -> {load_path}")
+            loaded_metamodel, state = type(metamodel).load(load_path)
+            if not metamodel.check_compatibility(loaded_metamodel):
+                raise ValueError("MCMC checkpoint is incompatible!")
+            loaded_metamodel.global_comm = metamodel.global_comm
+            loaded_metamodel.datasets = metamodel.datasets
+            metamodel = _reestimate_noise(loaded_metamodel)
+            resume_state = state.get("mcmc_state", None)
+            steps_done = state.get("step", 0)
+            # Load accumulated samples
+            samps_path = os.path.join(cfg["outdir"], "samples_mcmc_partial.npz")
+            if os.path.exists(samps_path):
+                all_samples = np.load(samps_path)["samples"]
+            print_once(f"[resume] Resuming MCMC from step {steps_done}")
+
+    t1 = time.time()
+
+    # Loop over chunks of MCMC, checkpoint after each
+    while steps_done < total_steps:
+        this_chunk = min(chunk_size, total_steps - steps_done)
+        metamodel, samples, resume_state = run_mcmc(
+            metamodel,
+            num_steps=this_chunk,
+            num_leaps=int(cfg["mcmc"].get("num_leaps", 10)),
+            step_size=jnp.array(float(cfg["mcmc"].get("step_size", 0.02))),
+            sample_which=int(cfg["mcmc"].get("sample_which", -1)),
+            burn_in=float(cfg["mcmc"].get("burn_in", 0.1)),
+            max_tries=int(cfg["mcmc"].get("max_tries", 20)),
+            resume_state=resume_state,
+        )
+        mpi4jax.barrier(comm=comm)
+        steps_done += this_chunk
+
+        # Accumulate samples (rank 0 only has real samples)
+        if comm.Get_rank() == 0:
+            samples = np.array(samples)
+            if all_samples is None:
+                all_samples = samples
+            else:
+                all_samples = np.concatenate([all_samples, samples], axis=0)
+
+            # Save checkpoint and partial samples
+            ckpt_path = os.path.join(
+                ckpt_dir, f"mcmc_step_{steps_done}{'_nonpara'*nonpara}.pkl"
+            )
+            _save_checkpoint(
+                ckpt_path,
+                metamodel,
+                cfg,
+                stage="mcmc",
+                step_num=steps_done,
+            )
+            # Re open to add mcmc_state
+            metamodel.save(
+                ckpt_path,
+                {
+                    "cfg": cfg,
+                    "stage": "mcmc",
+                    "step": steps_done,
+                    "mcmc_state": resume_state,
+                },
+            )
+            samps_path = os.path.join(cfg["outdir"], "samples_mcmc_partial.npz")
+            np.savez_compressed(samps_path, samples=all_samples)
+            print_once(
+                f"[checkpoint] Saved MCMC checkpoint at step {steps_done} -> {ckpt_path}"
+            )
+
+    mpi4jax.barrier(comm=comm)
+    t2 = time.time()
+    print_once(f"Took {t2 - t1}s to run mcmc")
+
+    message = str(metamodel).split("\n")
+    message[1] = "MCMC estimated pars:"
+    print_once("\n".join(message))
+
+    _save_model(cfg, metamodel, "mcmc", nonpara)
+    if comm.Get_rank() == 0:
+        samples = np.array(all_samples)
+        samps_path = os.path.join(cfg["outdir"], f"samples_mcmc.npz")
+        print_once("Saving samples to", samps_path)
+        np.savez_compressed(samps_path, samples=samples)
+        try:
+            to_fit = np.array(metamodel.to_fit)
+            corner.corner(
+                samples,
+                labels=np.array(metamodel.par_names)[to_fit],
+                truths=init_pars[to_fit],
+            )
+            plt.savefig(os.path.join(cfg["outdir"], "corner.png"))
+        except Exception as e:
+            print_once(f"Failed to make corner plot with error: {str(e)}")
+    else:
+        del samples
+
+    metamodel = _reestimate_noise(metamodel)
+    return metamodel
+
+
+"""
     # Tracking container for callback to update
     callback_state = {
         "step": 0,
@@ -472,6 +590,10 @@ def _run_mcmc(cfg, metamodel, nonpara=False):
         nonpara=nonpara,
         cfg=cfg,
     )
+
+    checkpoint_interval = int(cfg["mcmc"].get("checkpoint_interval", 200))
+    ckpt_dir = os.path.join(cfg["outdir"], "checkpoints")
+    os.makedirs(ckpt_dir, exist_ok=True)
 
     t1 = time.time()
     metamodel, samples = run_mcmc(
@@ -517,6 +639,7 @@ def _run_mcmc(cfg, metamodel, nonpara=False):
 
     metamodel = _reestimate_noise(metamodel)
     return metamodel
+"""
 
 
 def fit_loop(metamodel, cfg, comm, nonpara=False):

--- a/witch/fitting.py
+++ b/witch/fitting.py
@@ -377,7 +377,8 @@ def run_mcmc(
     sample_which: int = -1,
     burn_in: float = 0.1,
     max_tries: int = 20,
-) -> tuple[MetaModel, jax.Array]:
+    resume_state: dict = None,
+) -> tuple[MetaModel, jax.Array, dict]:
     """
     Run Hamilonian Monte Carlo to estimate the posterior for our model.
     Currently this function only support flat priors, but more will be supported
@@ -599,6 +600,45 @@ def run_mcmc(
             sys.stdout.flush()
         return step_size
 
+    # Determine chunk index for generating a different key for each chunk
+    # On a fresh run, this is 0; otherwise, we continue from where we left off
+    if resume_state is not None:
+        chunk_index = resume_state["chunk_index"]
+        step_size = jnp.array(resume_state["step_size"])
+        start_pars = jnp.array(resume_state["params"])
+        # Overwrite starting pos with where chain left off
+        init_pars = init_pars.at[to_fit].set(
+            start_pars.at[to_fit].get() / scale.at[to_fit].get()
+        )
+    else:
+        chunk_index = 0
+
+    base_key = jax.random.PRNGKey(0)
+    base_key = jnp.array(mpi4jax.bcast(base_key, 0, comm=global_comm))
+    """
+    Derive independent key for this chunk. HMC redraws momentum every step, so
+    a per chunk key is statistically valid and avoids threading the key out of hmc.
+    """
+    key = jax.random.fold_in(base_key, chunk_index)
+
+    # Only tune step size on first chunk
+    if resume_state is None:
+        step_size = _get_step_size(
+            step_size=step_size, key=key, comm=global_comm, max_tries=max_tries
+        )
+
+    chain, _ = hmc(
+        init_pars.at[to_fit].get().ravel(),
+        _log_prob,
+        _log_prob_grad,
+        num_steps=num_steps,
+        num_leaps=num_leaps,
+        step_size=step_size,
+        comm=global_comm,
+        key=key,
+    )
+
+    """
     key = jax.random.PRNGKey(0)
     key = jnp.array(mpi4jax.bcast(key, 0, comm=global_comm))
 
@@ -619,6 +659,7 @@ def run_mcmc(
         comm=global_comm,
         key=key,
     )
+    """
     flat_samples = chain.at[:].multiply(scale.at[to_fit].get())
 
     if rank == 0:
@@ -637,4 +678,19 @@ def run_mcmc(
     metamodel = metamodel.update(final_pars, final_errs, chisq)
     jax.block_until_ready(metamodel)
 
+    # Build state needed to resume from this chunk later
+    out_state = {
+        "chunk_index": chunk_index + 1,
+        "step_size": float(step_size),
+        "params": np.array(final_pars),
+    }
+
+    return metamodel, flat_samples, out_state
+
+    """
+    chisq, *_ = joint_objective(metamodel, True, False, False)
+    metamodel = metamodel.update(final_pars, final_errs, chisq)
+    jax.block_until_ready(metamodel)
+
     return metamodel, flat_samples
+    """


### PR DESCRIPTION
Replaces callback-based MCMC checkpointing with a loop-over run_mcmc approach.

Changes:

- `run_mcmc` now takes an optional `resume_state` and returns a state dict as a third value. The state carries the current chain position, tuned step size, and chunk index. When resuming, step-size tuning is skipped (confirmed with Saianeesh).
- PRNG keys for each chunk are derived with `jax.random.fold_in` rather than threading the evolved key out of `hmc`. Because HMC redraws momentum every step, a per chunk key is valid and also avoids changing the `hmc` signature.
- `_run_mcmc` now loops over `run_mcmc` in chunks of `checkpoint_interval` steps, saving a checkpoint and the accumulated samples after each chunk. On startup it resumes from the latest MCMC checkpoint if `load_progress` is set.

Note: I can't fully test it end-to-end because my local environment hits a pre-existing error: `run_pcg_wprior() got an unexpected keyword argument 'mask'`.