### PR TITLE
fix: pass cov to MetaModel.update in MCMC path

### DIFF
--- a/witch/fitting.py
+++ b/witch/fitting.py
@@ -467,7 +467,9 @@ def run_mcmc(
                 jnp.array(jnp.where(metamodel.to_fit, in_bounds, True)), 0, -1 * jnp.inf
             )
         )
-        temp_metamodel = copy(metamodel).update(full_pars, init_errs, jnp.array(0))
+        temp_metamodel = copy(metamodel).update(
+            full_pars, init_errs, metamodel.cov, jnp.array(0)
+        )
         chisq, *_ = joint_objective(temp_metamodel, True, False, False)
         log_like = -0.5 * chisq
         log_like = log_like + log_prior
@@ -485,7 +487,9 @@ def run_mcmc(
                 jnp.array(jnp.where(metamodel.to_fit, in_bounds, True)), 0, -1 * jnp.inf
             )
         )
-        temp_metamodel = copy(metamodel).update(full_pars, init_errs, jnp.array(0))
+        temp_metamodel = copy(metamodel).update(
+            full_pars, init_errs, metamodel.cov, jnp.array(0)
+        )
         _, grad, _ = joint_objective(temp_metamodel, False, True, False)
         grad = grad.at[:].multiply(1.0 / scale)
         log_like_grad = grad.at[to_fit].get().ravel()
@@ -631,10 +635,11 @@ def run_mcmc(
     metamodel = metamodel.update(
         final_pars.block_until_ready(),
         final_errs.block_until_ready(),
+        metamodel.cov,
         jnp.array(0).block_until_ready(),
     )
     chisq, *_ = joint_objective(metamodel, True, False, False)
-    metamodel = metamodel.update(final_pars, final_errs, chisq)
+    metamodel = metamodel.update(final_pars, final_errs, metamodel.cov, chisq)
     jax.block_until_ready(metamodel)
 
     return metamodel, flat_samples


### PR DESCRIPTION
`run_mcmc` currently raises `TypeError: MetaModel.update() missing 1 required positional argument: 'chisq'` on the first log-prob evaluation.

`MetaModel.update()` takes (pars, errs, cov, chisq), but four places it is called in the MCMC path pass only three positional args: `_log_prob`, `_log_prob_grad`, and the two final updates. The LM call sites use keyword args and pass cov, so it might have just been missed when cov was added to the signature.

Passes `metamodel.cov` at each site. In `_log_prob` / `_log_prob_grad` the covariance isn't used in the chisq calculation, so this preserves behavior. 

Verified by running RXJ1347_a10.yaml with an mcmc block and MCMC ran to completion.